### PR TITLE
Add 'required' field to select menu components

### DIFF
--- a/objects/interaction/component/component_channel_select.go
+++ b/objects/interaction/component/component_channel_select.go
@@ -11,6 +11,7 @@ type ChannelSelect struct {
 	MinValues   *int           `json:"min_values,omitempty"`
 	MaxValues   *int           `json:"max_values,omitempty"`
 	Disabled    *bool          `json:"disabled"`
+	Required    *bool          `json:"required,omitempty"`
 }
 
 func (i ChannelSelect) Type() ComponentType {

--- a/objects/interaction/component/component_mentionable_select.go
+++ b/objects/interaction/component/component_mentionable_select.go
@@ -11,6 +11,7 @@ type MentionableSelect struct {
 	MinValues   *int           `json:"min_values,omitempty"`
 	MaxValues   *int           `json:"max_values,omitempty"`
 	Disabled    *bool          `json:"disabled"`
+	Required    *bool          `json:"required,omitempty"`
 }
 
 func (i MentionableSelect) Type() ComponentType {

--- a/objects/interaction/component/component_role_select.go
+++ b/objects/interaction/component/component_role_select.go
@@ -11,6 +11,7 @@ type RoleSelect struct {
 	MinValues   *int           `json:"min_values,omitempty"`
 	MaxValues   *int           `json:"max_values,omitempty"`
 	Disabled    *bool          `json:"disabled"`
+	Required    *bool          `json:"required,omitempty"`
 }
 
 func (i RoleSelect) Type() ComponentType {

--- a/objects/interaction/component/component_user_select.go
+++ b/objects/interaction/component/component_user_select.go
@@ -10,6 +10,7 @@ type UserSelect struct {
 	MinValues   *int   `json:"min_values,omitempty"`
 	MaxValues   *int   `json:"max_values,omitempty"`
 	Disabled    *bool  `json:"disabled"`
+	Required    *bool  `json:"required,omitempty"`
 }
 
 func (i UserSelect) Type() ComponentType {

--- a/objects/interaction/component/selectmenu.go
+++ b/objects/interaction/component/selectmenu.go
@@ -13,6 +13,7 @@ type SelectMenu struct {
 	MinValues   *int           `json:"min_values,omitempty"`
 	MaxValues   *int           `json:"max_values,omitempty"`
 	Disabled    bool           `json:"disabled"`
+	Required    *bool          `json:"required,omitempty"`
 }
 
 type SelectOption struct {


### PR DESCRIPTION
Introduces an optional 'Required' boolean field to ChannelSelect, MentionableSelect, RoleSelect, UserSelect, and SelectMenu structs to support marking select menu components as required in the interaction component system.