### PR TITLE
Add support for interaction command contexts

### DIFF
--- a/objects/interaction/applicationcommand.go
+++ b/objects/interaction/applicationcommand.go
@@ -1,13 +1,14 @@
 package interaction
 
 type ApplicationCommand struct {
-	Id                uint64                     `json:"id,string,omitempty"`
-	Type              ApplicationCommandType     `json:"application_command_type"`
-	ApplicationId     uint64                     `json:"application_id,string,omitempty"`
-	Name              string                     `json:"name"`
-	Description       string                     `json:"description"`
-	Options           []ApplicationCommandOption `json:"options"`
-	DefaultPermission bool                       `json:"default_permission,omitempty"`
+	Id                uint64                      `json:"id,string,omitempty"`
+	Type              ApplicationCommandType      `json:"application_command_type"`
+	ApplicationId     uint64                      `json:"application_id,string,omitempty"`
+	Name              string                      `json:"name"`
+	Description       string                      `json:"description"`
+	Options           []ApplicationCommandOption  `json:"options"`
+	DefaultPermission bool                        `json:"default_permission,omitempty"`
+	Contexts          []InteractionContextType    `json:"contexts,omitempty"`
 }
 
 type ApplicationCommandType uint8

--- a/objects/interaction/interactioncontext.go
+++ b/objects/interaction/interactioncontext.go
@@ -1,24 +1,9 @@
 package interaction
 
-import "encoding/json"
-
-type InteractionContextType uint8
+type InteractionContextType int8
 
 const (
 	InteractionContextGuild InteractionContextType = 0
 	InteractionContextBotDM InteractionContextType = 1
 	InteractionContextPrivateChannel InteractionContextType = 2
 )
-
-func (i InteractionContextType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(uint8(i))
-}
-
-func (i *InteractionContextType) UnmarshalJSON(data []byte) error {
-	var val uint8
-	if err := json.Unmarshal(data, &val); err != nil {
-		return err
-	}
-	*i = InteractionContextType(val)
-	return nil
-}

--- a/objects/interaction/interactioncontext.go
+++ b/objects/interaction/interactioncontext.go
@@ -1,0 +1,24 @@
+package interaction
+
+import "encoding/json"
+
+type InteractionContextType uint8
+
+const (
+	InteractionContextGuild InteractionContextType = 0
+	InteractionContextBotDM InteractionContextType = 1
+	InteractionContextPrivateChannel InteractionContextType = 2
+)
+
+func (i InteractionContextType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(uint8(i))
+}
+
+func (i *InteractionContextType) UnmarshalJSON(data []byte) error {
+	var val uint8
+	if err := json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+	*i = InteractionContextType(val)
+	return nil
+}

--- a/rest/interaction.go
+++ b/rest/interaction.go
@@ -29,6 +29,7 @@ type CreateCommandData struct {
 	Description string                                 `json:"description"`
 	Options     []interaction.ApplicationCommandOption `json:"options"`
 	Type        interaction.ApplicationCommandType     `json:"type"`
+	Contexts    []interaction.InteractionContextType   `json:"contexts,omitempty"`
 }
 
 func CreateGlobalCommand(ctx context.Context, token string, rateLimiter *ratelimit.Ratelimiter, applicationId uint64, data CreateCommandData) (command interaction.ApplicationCommand, err error) {


### PR DESCRIPTION
Introduces the InteractionContextType type and related constants to specify command contexts (guild, bot DM, private channel). Updates ApplicationCommand and CreateCommandData structs to include a Contexts field, allowing commands to define their applicable contexts.