### PR TITLE
Add new Discord permissions to Permission enum

### DIFF
--- a/permission/permission.go
+++ b/permission/permission.go
@@ -50,7 +50,7 @@ const (
 	CreateEvents
 	UseExternalSounds
 	SendVoiceMessages
-	SendPolls       Permission = 1 << 49
+	SendPolls       Permission = 1 << 49 // Explicit bit position (bits 47-48 are skipped by Discord)
 	UseExternalApps Permission = 1 << 50
 	PinMessages     Permission = 1 << 51
 )

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -44,6 +44,15 @@ const (
 	SendMessagesInThreads
 	UseEmbeddedActivities
 	ModerateMembers
+	ViewCreatorMonetizationAnalytics
+	UseSoundboard
+	CreateGuildExpressions
+	CreateEvents
+	UseExternalSounds
+	SendVoiceMessages
+	SendPolls       Permission = 1 << 49
+	UseExternalApps Permission = 1 << 50
+	PinMessages     Permission = 1 << 51
 )
 
 func HasPermissionRaw(permissions uint64, permission Permission) bool {
@@ -144,6 +153,24 @@ func (p Permission) String() string {
 		return "Use Embedded Activities"
 	case ModerateMembers:
 		return "Moderate Members"
+	case ViewCreatorMonetizationAnalytics:
+		return "View Creator Monetization Analytics"
+	case UseSoundboard:
+		return "Use Soundboard"
+	case CreateGuildExpressions:
+		return "Create Guild Expressions"
+	case CreateEvents:
+		return "Create Events"
+	case UseExternalSounds:
+		return "Use External Sounds"
+	case SendVoiceMessages:
+		return "Send Voice Messages"
+	case SendPolls:
+		return "Send Polls"
+	case UseExternalApps:
+		return "Use External Apps"
+	case PinMessages:
+		return "Pin Messages"
 	default:
 		return "Unknown Permission"
 	}
@@ -191,4 +218,13 @@ var AllPermissions = []Permission{
 	SendMessagesInThreads,
 	UseEmbeddedActivities,
 	ModerateMembers,
+	ViewCreatorMonetizationAnalytics,
+	UseSoundboard,
+	CreateGuildExpressions,
+	CreateEvents,
+	UseExternalSounds,
+	SendVoiceMessages,
+	SendPolls,
+	UseExternalApps,
+	PinMessages,
 }


### PR DESCRIPTION
## Description
Added several new permissions to the Permission enum, including ViewCreatorMonetizationAnalytics, UseSoundboard, CreateGuildExpressions, CreateEvents, UseExternalSounds, SendVoiceMessages, SendPolls, UseExternalApps, and PinMessages. Updated the String method and AllPermissions slice to support these new permissions.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Updates

## Testing
I made tickets add the pin messages permission 

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
