### PR TITLE
Add BypassSlowmode Permission

### DIFF
--- a/permission/permission.go
+++ b/permission/permission.go
@@ -55,6 +55,7 @@ const (
 	SendPolls
 	UseExternalApps
 	PinMessages
+	BypassSlowmode
 )
 
 func HasPermissionRaw(permissions uint64, permission Permission) bool {

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -50,9 +50,11 @@ const (
 	CreateEvents
 	UseExternalSounds
 	SendVoiceMessages
-	SendPolls       Permission = 1 << 49 // Explicit bit position (bits 47-48 are skipped by Discord)
-	UseExternalApps Permission = 1 << 50
-	PinMessages     Permission = 1 << 51
+	_
+	_
+	SendPolls
+	UseExternalApps
+	PinMessages
 )
 
 func HasPermissionRaw(permissions uint64, permission Permission) bool {


### PR DESCRIPTION
Adds BypassSlowmode Permission https://discord.com/developers/docs/topics/permissions#permissions:~:text=T-,BYPASS_SLOWMODE

And replaced explicit bit positions for SendPolls, UseExternalApps, and PinMessages with skipped placeholders to align with Discord's permission bit layout, ensuring correct mapping and future maintainability.