### PR TITLE
Increase HTTP client timeout settings to 10 seconds by default

### DIFF
--- a/rest/request/endpoint.go
+++ b/rest/request/endpoint.go
@@ -66,9 +66,9 @@ func RegisterPostRequestHook(hook func(*http.Response, []byte)) {
 // TODO: Allow users to specify custom timeouts
 var Client = http.Client{
 	Transport: &http.Transport{
-		TLSHandshakeTimeout: time.Second * 3,
+		TLSHandshakeTimeout: time.Second * 10,
 	},
-	Timeout: time.Second * 3,
+	Timeout: time.Second * 10,
 }
 
 func (e *Endpoint) Request(ctx context.Context, token string, body any, response any) (error, *ResponseWithContent) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Checklist
- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
