### PR TITLE
RM-257: Fix being able to close a ticket, including a premium button

### DIFF
--- a/objects/interaction/component/componentbutton.go
+++ b/objects/interaction/component/componentbutton.go
@@ -11,7 +11,7 @@ type Button struct {
 	CustomId string       `json:"custom_id,omitempty"`
 	Style    ButtonStyle  `json:"style"`
 	Emoji    *emoji.Emoji `json:"emoji,omitempty"`
-	SkuId    *uint64      `json:"sku_id,omitempty"`
+	SkuId    *uint64      `json:"sku_id,string,omitempty"`
 	Url      *string      `json:"url,omitempty"`
 	Disabled bool         `json:"disabled"`
 }


### PR DESCRIPTION
## Description
RM-257
Add the ,string JSON tag to Button.SkuId so uint64 SKU IDs are encoded/decoded as JSON strings. This avoids precision loss in JavaScript consumers and matches APIs that represent large numeric IDs as strings.

Both the API and worker needs to get gdl bumped when this is accepted

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
 
## Testing
- Overwrite gdl in the API and worker
- Make a ticket 
- Send a message with a premium button in the ticket https://docs.discord.com/developers/components/reference#button
- Try to view the ticket via the dashboard (should be viewable now) 
- Try to close the ticket (should close without error)

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
